### PR TITLE
Fixed bug in argument parsing

### DIFF
--- a/js_test_tool/features/terrain.py
+++ b/js_test_tool/features/terrain.py
@@ -81,7 +81,7 @@ def run_tool_with_args(arg_list):
     """
 
     # Install the arguments
-    world.mock_sys.argv = arg_list + BROWSER_ARGS
+    world.mock_sys.argv = ["js-test-tool"] + arg_list + BROWSER_ARGS
 
     # Run the tool
     tool.main()

--- a/js_test_tool/tests/test_args.py
+++ b/js_test_tool/tests/test_args.py
@@ -6,8 +6,10 @@ import os
 
 class ParseArgsTest(unittest.TestCase):
 
+    TOOL_NAME = "js-test-tool"
+
     def test_parse_test_suite_file(self):
-        argv = ['test_suite.yaml', '--use-phantomjs']
+        argv = [self.TOOL_NAME, 'test_suite.yaml', '--use-phantomjs']
         arg_dict = parse_args(argv)
 
         self.assertEqual(arg_dict.get('test_suite_paths'), ['test_suite.yaml'])
@@ -15,26 +17,26 @@ class ParseArgsTest(unittest.TestCase):
         self.assertIs(arg_dict.get('coverage_html'), None)
 
     def test_parse_test_suite_multiple_files(self):
-        argv = ['test_suite_1.yaml', 'test_suite_2.yaml', '--use-chrome']
+        argv = [self.TOOL_NAME, 'test_suite_1.yaml', 'test_suite_2.yaml', '--use-chrome']
         arg_dict = parse_args(argv)
 
         self.assertEqual(arg_dict.get('test_suite_paths'),
                          ['test_suite_1.yaml', 'test_suite_2.yaml'])
 
     def test_parse_coverage_xml(self):
-        argv = ['test_suite.yaml', '--coverage-xml',
+        argv = [self.TOOL_NAME, 'test_suite.yaml', '--coverage-xml',
                 'coverage.xml', '--use-firefox']
         arg_dict = parse_args(argv)
         self.assertEqual(arg_dict.get('coverage_xml'), 'coverage.xml')
 
     def test_parse_coverage_html(self):
-        argv = ['test_suite.yaml', '--coverage-html', 'coverage.html',
+        argv = [self.TOOL_NAME, 'test_suite.yaml', '--coverage-html', 'coverage.html',
                 '--use-firefox']
         arg_dict = parse_args(argv)
         self.assertEqual(arg_dict.get('coverage_html'), 'coverage.html')
 
     def test_parse_coverage_xml_and_html(self):
-        argv = ['test_suite.yaml',
+        argv = [self.TOOL_NAME, 'test_suite.yaml',
                 '--coverage-xml', 'coverage.xml',
                 '--coverage-html', 'coverage.html',
                 '--use-phantomjs']
@@ -49,13 +51,13 @@ class ParseArgsTest(unittest.TestCase):
                  ('--use-firefox', 'firefox')]
 
         for (browser_arg, browser_name) in cases:
-            argv = ['test_suite.yaml', browser_arg]
+            argv = [self.TOOL_NAME, 'test_suite.yaml', browser_arg]
             arg_dict = parse_args(argv)
             self.assertEqual(arg_dict.get('browser_names'), [browser_name])
 
     def test_parse_all_browsers(self):
 
-        argv = ['test_suite.yaml', '--use-phantomjs',
+        argv = [self.TOOL_NAME, 'test_suite.yaml', '--use-phantomjs',
                 '--use-chrome', '--use-firefox']
 
         arg_dict = parse_args(argv)
@@ -67,6 +69,9 @@ class ParseArgsTest(unittest.TestCase):
         invalid_argv = [
             # No arguments
             [],
+
+            # No browser or suite description
+            [self.TOOL_NAME],
 
             # No browser
             ['test_suite.yaml', '--coverage-xml', 'coverage.xml'],

--- a/js_test_tool/tool.py
+++ b/js_test_tool/tool.py
@@ -46,6 +46,9 @@ def parse_args(argv):
 
     `BROWSER_NAMES` is the list of browsers under which to run the tests.
 
+    `argv` is the list of command line arguments, starting with
+    the name of the program.
+
     Raises an `IOError` if the test suite description does not exist.
     Raises a `SystemExit` exception if arguments are otherwise invalid.
     """
@@ -66,13 +69,14 @@ def parse_args(argv):
                             help=browser_help)
 
     # Parse the arguments
-    arg_dict = vars(parser.parse_args(argv))
+    # Exclude the first argument, which is the name of the program
+    arg_dict = vars(parser.parse_args(argv[1:]))
 
     # Check that we have at least one browser specified
     if not arg_dict.get('browser_names'):
         raise SystemExit('You must specify at least one browser.')
 
-    return vars(parser.parse_args(argv))
+    return arg_dict
 
 
 def generate_reports(suite_runner, output_file):


### PR DESCRIPTION
The bug was caused by forgetting that sys.argv[0] is the name of the program.
