### PR TITLE
README / error message for up-level references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,11 @@ This will create a YAML file that looks like:
 
 * JavaScript files are loaded in the specified order.
 
+* Paths cannot contain up-level references. For example, ``path/to/dir`` is okay,
+  but ``../path/to/dir`` is not.
+  If you need to access files in directories above the test suite directory,
+  use symbolic links.
+
 2. Run the test suite.
 
 .. code:: bash

--- a/js_test_tool/suite.py
+++ b/js_test_tool/suite.py
@@ -346,7 +346,8 @@ class SuiteDescription(object):
         # Check that we are not using double-dot relative paths
         for key in ['lib_paths', 'src_paths', 'spec_paths', 'fixture_paths']:
             if key in desc_dict and cls.path_list_has_double_dot(desc_dict[key]):
-                msg = "Paths cannot use up-level references (..)"
+                msg = ("Paths cannot use up-level references (e.g. ../path/to/dir).  " +
+                      "Try using a symbolic link instead.")
                 raise SuiteDescriptionError(msg)
 
     @staticmethod


### PR DESCRIPTION
Added note to README about using symlinks instead of up-level path references.

Added more descriptive error message for up-level references.
