### PR TITLE
Will/failsafe

### DIFF
--- a/js_test_tool/util.py
+++ b/js_test_tool/util.py
@@ -2,10 +2,16 @@
 Utility functions.
 """
 import time
+import logging
+
+LOGGER = logging.getLogger(__name__)
 
 
 def retry(try_func, max_attempts, wait_sec,
-          recover_func=None, fail_fast_errors=None):
+          recover_func=None,
+          num_attempts_before_recover=1,
+          fail_fast_errors=None,
+          name=''):
     """
     Call `try_func` (lambda with no args) until it executes
     with no exception.  If the function does not succeed after
@@ -17,8 +23,13 @@ def retry(try_func, max_attempts, wait_sec,
     before retrying.  It should accept no arguments,
     and its return value is ignored.
 
+    `num_attempts_before_recover` allows you to delay the recover
+    attempt until the `try_func` fails a few times.
+
     `fail_fast_exceptions` is an optional list of exception types
     for which to fail immediately.
+
+    `name` is a unique name to use in log messages.
 
     Returns the output of the successful call to `try_func`.
     """
@@ -34,6 +45,8 @@ def retry(try_func, max_attempts, wait_sec,
 
         except BaseException as ex:
 
+            LOGGER.debug("{0}: Retrying after catching exception: {1}".format(name, ex))
+
             # Check if this is a fail fast exception
             # If it is, re-raise the exception immediately
             if fail_fast_errors is not None:
@@ -44,11 +57,13 @@ def retry(try_func, max_attempts, wait_sec,
             # Check if we are out of attempts
             num_attempts += 1
             if num_attempts >= max_attempts:
+                LOGGER.debug("{0}: Exceeded maximum number of attempts.".format(name))
                 raise ex
 
             # Otherwise, wait a bit and retry
             time.sleep(wait_sec)
 
             # Perform the recover function if one is provided
-            if recover_func is not None:
+            if (recover_func is not None and num_attempts >= num_attempts_before_recover):
+                LOGGER.debug("{0}: Attempting recovery function.".format(name))
                 recover_func()


### PR DESCRIPTION
Better retry logic to handle cases where the Browser or JSCover processes die.
This won't solve the case where there's not enough memory available, but it should alleviate issues due to temporary spikes in memory usage by other processes.
