### PR TITLE
Always return Content-Length to support keep-alive requirements

### DIFF
--- a/js_test_tool/suite_server.py
+++ b/js_test_tool/suite_server.py
@@ -967,6 +967,10 @@ class SuitePageRequestHandler(BaseHTTPRequestHandler):
 
             self.send_header('Content-Length', end_pos - start_pos + 1)
 
+        else:
+            content_length = self._file_size(content) if content is not None else 0
+            self.send_header('Content-Length', content_length)
+
         self.end_headers()
 
         # Send the content

--- a/js_test_tool/tests/test_suite_server.py
+++ b/js_test_tool/tests/test_suite_server.py
@@ -449,10 +449,24 @@ class SuitePageServerTest(TempWorkspaceTestCase):
         # Expect that we get a success result code
         self.assertEqual(response.status_code, requests.codes.ok, msg=url)
 
+        # Expect that we got an accurate content length
+        if encoding is None:
+            expected_len = len(expected_content)
+        else:
+            expected_len = len(expected_content.encode(encoding))
+
+        self.assertEqual(
+            str(expected_len),
+            response.headers.get('content-length')
+        )
+
         # Expect that the content is what we rendered
         if encoding is not None:
-            self.assertIn(expected_content,
-                          response.content.decode(encoding), msg=url)
+            self.assertIn(
+                expected_content,
+                response.content.decode(encoding),
+                msg=url
+            )
 
         # If no encoding, just expect the byte string
         else:


### PR DESCRIPTION
Fixes a bug observed in Chrome on Xubuntu 12.04 in which pages would fail to load because Content-Length was not being sent with all responses.
