### PR TITLE
Handle coverage timeout gracefully

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,1 @@
-
+* Graceful handling of when JSCover won't start because not enough memory is available.


### PR DESCRIPTION
Sometimes, JSCover will not be able to instrument the source files, despite repeated attempts.  This occurs when there's not enough memory to run JSCover.

Previously, this would cause the tool to fail with a timeout error as it waited for coverage data that would never be reported.  This PR handles the case more gracefully by printing a warning without re-raising the exception.  Although no coverage data will be reported, the build will no longer fail.
