### PR TITLE
Enforce correct order for lib files in acceptance test fixture

### DIFF
--- a/js_test_tool/features/fixtures/jasmine/test_suite.yaml
+++ b/js_test_tool/features/fixtures/jasmine/test_suite.yaml
@@ -2,7 +2,8 @@
 test_suite_name: jasmine
 prepend_path: base
 lib_paths:
-    - lib
+    - lib/jquery.js
+    - lib/jasmine-jquery.js
 spec_paths: 
     - spec
 src_paths: 


### PR DESCRIPTION
JQuery needs to be loaded before jasmine-jquery in one of the acceptance test fixtures.
