### PR TITLE
Changed XUnit report format to display better in Jenkins.

### DIFF
--- a/js_test_tool/features/fixtures/expected/jasmine_xunit.xml
+++ b/js_test_tool/features/fixtures/expected/jasmine_xunit.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" ?>
 <testsuite name="javascript" errors="0" failures="2" skipped="0" tests="8">
-    <testcase classname="[firefox] Adder" name="should start at zero">
+    <testcase classname="JavaScript.firefox" name="Adder: should start at zero">
     </testcase>
-    <testcase classname="[firefox] Adder" name="should add to the sum">
+    <testcase classname="JavaScript.firefox" name="Adder: should add to the sum">
     </testcase>
-    <testcase classname="[firefox] Adder" name="should keep a running total">
+    <testcase classname="JavaScript.firefox" name="Adder: should keep a running total">
     </testcase>
-    <testcase classname="[firefox] Adder" name="should output to the DOM">
+    <testcase classname="JavaScript.firefox" name="Adder: should output to the DOM">
         <failure type="Failure" message=""><![CDATA[Expected '' to equal '3'.]]></failure>
     </testcase>
-    <testcase classname="[phantomjs] Adder" name="should start at zero">
+    <testcase classname="JavaScript.phantomjs" name="Adder: should start at zero">
     </testcase>
-    <testcase classname="[phantomjs] Adder" name="should add to the sum">
+    <testcase classname="JavaScript.phantomjs" name="Adder: should add to the sum">
     </testcase>
-    <testcase classname="[phantomjs] Adder" name="should keep a running total">
+    <testcase classname="JavaScript.phantomjs" name="Adder: should keep a running total">
     </testcase>
-    <testcase classname="[phantomjs] Adder" name="should output to the DOM">
+    <testcase classname="JavaScript.phantomjs" name="Adder: should output to the DOM">
         <failure type="Failure" message=""><![CDATA[Expected '' to equal '3'.]]></failure>
     </testcase>
 </testsuite>

--- a/js_test_tool/templates/xunit_report.txt
+++ b/js_test_tool/templates/xunit_report.txt
@@ -2,7 +2,7 @@
 <testsuite name="javascript" errors="{{ stats.num_error }}" failures="{{ stats.num_failed }}" skipped="{{ stats.num_skipped }}" tests="{{ stats.num_tests }}">
     {% for browser_dict in browser_results %}
     {% for test_result in browser_dict.test_results %}
-    <testcase classname="[{{ browser_dict.browser_name }}] {{ test_result.test_group }}" name="{{ test_result.test_name }}">
+    <testcase classname="JavaScript.{{ browser_dict.browser_name }}" name="{{ test_result.test_group }}: {{ test_result.test_name }}">
         {% if test_result.status == "fail" %}
         <failure type="Failure" message=""><![CDATA[{{ test_result.detail }}]]></failure>
         {% elif test_result.status == "error" %}

--- a/js_test_tool/tests/test_result_report.py
+++ b/js_test_tool/tests/test_result_report.py
@@ -601,11 +601,11 @@ class XUnitResultReporterTest(ResultReporterTestCase):
         expected_report = dedent("""
         <?xml version="1.0" ?>
         <testsuite name="javascript" errors="0" failures="0" skipped="0" tests="3">
-            <testcase classname="[chrome] Adder test" name="it should start at zero">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should start at zero">
             </testcase>
-            <testcase classname="[chrome] Adder test" name="it should add to the sum">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should add to the sum">
             </testcase>
-            <testcase classname="[chrome] Multiplier test" name="it should multiply">
+            <testcase classname="JavaScript.chrome" name="Multiplier test: it should multiply">
             </testcase>
         </testsuite>
         """)
@@ -634,13 +634,13 @@ class XUnitResultReporterTest(ResultReporterTestCase):
         expected_report = dedent("""
         <?xml version="1.0" ?>
         <testsuite name="javascript" errors="0" failures="1" skipped="0" tests="3">
-            <testcase classname="[chrome] Adder test" name="it should start at zero">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should start at zero">
             </testcase>
-            <testcase classname="[chrome] Adder test" name="it should add to the sum">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should add to the sum">
                 <failure type="Failure" message=""><![CDATA[Stack trace
         Can go here]]></failure>
             </testcase>
-            <testcase classname="[chrome] Multiplier test" name="it should multiply">
+            <testcase classname="JavaScript.chrome" name="Multiplier test: it should multiply">
             </testcase>
         </testsuite>
         """)
@@ -669,13 +669,13 @@ class XUnitResultReporterTest(ResultReporterTestCase):
         expected_report = dedent("""
         <?xml version="1.0" ?>
         <testsuite name="javascript" errors="0" failures="3" skipped="0" tests="3">
-            <testcase classname="[chrome] Adder test" name="it should start at zero">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should start at zero">
                 <failure type="Failure" message=""><![CDATA[Desc]]></failure>
             </testcase>
-            <testcase classname="[chrome] Adder test" name="it should add to the sum">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should add to the sum">
                 <failure type="Failure" message=""><![CDATA[Desc]]></failure>
             </testcase>
-            <testcase classname="[chrome] Multiplier test" name="it should multiply">
+            <testcase classname="JavaScript.chrome" name="Multiplier test: it should multiply">
                 <failure type="Failure" message=""><![CDATA[Desc]]></failure>
             </testcase>
         </testsuite>
@@ -705,12 +705,12 @@ class XUnitResultReporterTest(ResultReporterTestCase):
         expected_report = dedent("""
         <?xml version="1.0" ?>
         <testsuite name="javascript" errors="1" failures="0" skipped="0" tests="3">
-            <testcase classname="[chrome] Adder test" name="it should start at zero">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should start at zero">
             </testcase>
-            <testcase classname="[chrome] Adder test" name="it should add to the sum">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should add to the sum">
                 <error type="Error" message=""><![CDATA[Desc]]></error>
             </testcase>
-            <testcase classname="[chrome] Multiplier test" name="it should multiply">
+            <testcase classname="JavaScript.chrome" name="Multiplier test: it should multiply">
             </testcase>
         </testsuite>
         """)
@@ -739,12 +739,12 @@ class XUnitResultReporterTest(ResultReporterTestCase):
         expected_report = dedent("""
         <?xml version="1.0" ?>
         <testsuite name="javascript" errors="0" failures="0" skipped="1" tests="3">
-            <testcase classname="[chrome] Adder test" name="it should start at zero">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should start at zero">
             </testcase>
-            <testcase classname="[chrome] Adder test" name="it should add to the sum">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should add to the sum">
                 <skipped/>
             </testcase>
-            <testcase classname="[chrome] Multiplier test" name="it should multiply">
+            <testcase classname="JavaScript.chrome" name="Multiplier test: it should multiply">
             </testcase>
         </testsuite>
         """)
@@ -793,13 +793,13 @@ class XUnitResultReporterTest(ResultReporterTestCase):
         expected_report = dedent("""
         <?xml version="1.0" ?>
         <testsuite name="javascript" errors="0" failures="0" skipped="0" tests="4">
-            <testcase classname="[chrome] Adder test" name="it should start at zero">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should start at zero">
             </testcase>
-            <testcase classname="[chrome] Adder test" name="it should add to the sum">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should add to the sum">
             </testcase>
-            <testcase classname="[firefox] Adder test" name="it should start at zero">
+            <testcase classname="JavaScript.firefox" name="Adder test: it should start at zero">
             </testcase>
-            <testcase classname="[firefox] Adder test" name="it should add to the sum">
+            <testcase classname="JavaScript.firefox" name="Adder test: it should add to the sum">
             </testcase>
         </testsuite>
         """)
@@ -835,14 +835,14 @@ class XUnitResultReporterTest(ResultReporterTestCase):
         expected_report = dedent("""
         <?xml version="1.0" ?>
         <testsuite name="javascript" errors="0" failures="1" skipped="0" tests="4">
-            <testcase classname="[chrome] Adder test" name="it should start at zero">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should start at zero">
             </testcase>
-            <testcase classname="[chrome] Adder test" name="it should add to the sum">
+            <testcase classname="JavaScript.chrome" name="Adder test: it should add to the sum">
             </testcase>
-            <testcase classname="[firefox] Adder test" name="it should start at zero">
+            <testcase classname="JavaScript.firefox" name="Adder test: it should start at zero">
                 <failure type="Failure" message=""><![CDATA[Desc]]></failure>
             </testcase>
-            <testcase classname="[firefox] Adder test" name="it should add to the sum">
+            <testcase classname="JavaScript.firefox" name="Adder test: it should add to the sum">
             </testcase>
         </testsuite>
         """)


### PR DESCRIPTION
Jenkins uses whitespace in the "classname" attribute to group tests.  This leads to strange groupings for the edx-platform Jasmine tests.

This PR sets the classname to "JavaScript.BROWSER" to ensure that JS tests are grouped together in the output.  It's not ideal, but it should make it easier to find test results.
