### PR TITLE
Start server on address 0.0.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.1.5
+* Start the server on port 0.0.0.0 so this can be run on Vagrant
+
 v0.1.4
 * When JSCover fails, serve uninstrumented sources.
 

--- a/js_test_tool/__init__.py
+++ b/js_test_tool/__init__.py
@@ -2,7 +2,7 @@
 Perform global initialization.
 """
 
-VERSION = '0.1.4'
+VERSION = '0.1.5'
 DESCRIPTION = 'Run JavaScript test suites and collect coverage information.'
 
 # Configure the logger

--- a/js_test_tool/suite_server.py
+++ b/js_test_tool/suite_server.py
@@ -91,7 +91,7 @@ class SuitePageServer(ThreadingMixIn, HTTPServer):
         self.src_instr_dict = {}
 
         # Using port 0 assigns us an unused port
-        address = ('127.0.0.1', 0)
+        address = ('0.0.0.0', 0)
         HTTPServer.__init__(self, address, SuitePageRequestHandler)
 
     def start(self):

--- a/js_test_tool/tests/test_suite_server.py
+++ b/js_test_tool/tests/test_suite_server.py
@@ -61,7 +61,7 @@ class SuitePageServerTest(TempWorkspaceTestCase):
     def test_root_url(self):
 
         # Check that the root URL has the right form
-        url_regex = re.compile('^http://127.0.0.1:[0-9]+/$')
+        url_regex = re.compile('^http://0.0.0.0:[0-9]+/$')
         url = self.server.root_url()
         result = url_regex.match(url)
         self.assertIsNot(result, None,

--- a/scripts/acceptance_reqs.sh
+++ b/scripts/acceptance_reqs.sh
@@ -7,7 +7,7 @@ LETTUCE_FIXTURES_DIR=js_test_tool/features/fixtures
 JS_LIB_DIR=$LETTUCE_FIXTURES_DIR/jasmine/lib
 JSCOVER_DIR=$LETTUCE_FIXTURES_DIR/jscover
 
-JSCOVER_URL=http://superb-dca2.dl.sourceforge.net/project/jscover/JSCover-1.0.2.zip
+JSCOVER_URL=http://softlayer-dal.dl.sourceforge.net/project/jscover/JSCover-1.0.2.zip
 JQUERY_URL=http://code.jquery.com/jquery-1.10.1.min.js
 JASMINE_JQUERY_URL=https://raw.github.com/velesin/jasmine-jquery/master/lib/jasmine-jquery.js 
 


### PR DESCRIPTION
When running js-test-tool on a Vagrant instance, we want to use a browser on the host machine.  By starting the server on port 0.0.0.0 instead of 127.0.0.1, we make it accessible externally.

@jzoldak please review

@andy-armstrong When this gets merged, you will need to update `edx-platform/requirements/edx/github.txt` so that you're using js-test-tool version 0.1.5
